### PR TITLE
Prepare for upstream changes of influxdata repo

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -38,7 +38,7 @@
 
 - name: Add influxdb repo
   apt_repository:
-    repo: "deb https://repos.influxdata.com/{{ ansible_distribution.lower() }}/ {{ ansible_distribution_release  }} stable"
+    repo: "deb https://repos.influxdata.com/{{ ansible_distribution.lower() }} stable main"
     state: present
   tags: [influxdb]
 


### PR DESCRIPTION
InfluxData discontinued the use of distribution specific releases for Debian or Ubuntu based systems